### PR TITLE
chore(ci): upgrade gh actions versions

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '18.x'
+          node-version: '24.x'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -18,7 +18,11 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '18.x'
-          cache: 'pnpm'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
 
       - name: Install packages
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -13,9 +13,9 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: '18.x'
           cache: 'pnpm'

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -13,14 +13,14 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # 6.0.3
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # 6.4.0
         with:
           node-version: '24.x'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # 6.0.8
         with:
           run_install: false
 

--- a/package.json
+++ b/package.json
@@ -26,5 +26,6 @@
         "constructs": "^10.0.0",
         "dotenv": "^16.0.3",
         "source-map-support": "^0.5.21"
-    }
+    },
+    "packageManager": "pnpm@9.15.0"
 }


### PR DESCRIPTION
Looks like there were historical issue with the workflow for this repo. 

Have upgraded actions and fixed the pipeline, I've upgraded the version of Node here. There is no risk to the application, Node is only being used here for PR checks. There is no workflow to deploy application code or infra.